### PR TITLE
add covid columns

### DIFF
--- a/app/assets/stylesheets/layout.scss
+++ b/app/assets/stylesheets/layout.scss
@@ -31,6 +31,40 @@ html, body {
   width: 200px;
   height: 100%;
   background-color: #fff;
+
+  #covid-cards{
+    width: 100%;
+    height: calc(100vh - 60px);
+    overflow: auto;
+    .covid-card{
+      width: 100%;
+      height: 70px;
+      padding: 10px;
+      border-bottom: 1px solid #eee;
+
+      p{
+        font-size: 14px;
+        line-height: 11px;
+        color: #666;
+      }
+      &-main{
+        height: 100%;
+        display: flex;
+        padding-top: 10px;
+        justify-content: space-around;
+        // color: #333;
+        &__pref{
+          font-size: 20px;
+        }
+        &__data{
+          font-size: 24px;
+          &--total {
+            color: red;
+          }
+        }
+      }
+    }
+  }
 }
 
 .main-contents {
@@ -44,6 +78,20 @@ html, body {
   width: 100%;
   height: 300px;
   background-color: #123;
+  display: flex;
+  justify-content: space-between;
+  .heatmap-topics {
+    width: 360px;
+    padding: 0 30px;
+    border-left: 1px solid #666;
+    h3 {
+      line-height: 30px;
+      width: 100%;
+      height: 30px;
+      text-align: center;
+      color: #fff
+    }
+  }
 }
 
 .article-fields {
@@ -64,6 +112,7 @@ html, body {
     width:30%;
   }
 }
+
 
 
 /* タブレット表示時 */

--- a/app/javascript/japan-heatmap.js
+++ b/app/javascript/japan-heatmap.js
@@ -1,0 +1,63 @@
+document.addEventListener("turbolinks:load", function(){
+
+  function defineData(){
+    const data = {
+      "date" : "2020/08/27",
+      "total_patient_person_number": 65769,
+      "new_patient_person_number": 865,
+      "prefectures" : [10,2,0,1,0,0,7,8,1,18,69,45,250,66,1,8,13,13,0,6,2,12,39,6,5,27,94,22,4,0,0,0,1,1,6,4,0,0,0,64,2,7,6,1,1,2,36]
+    }
+    return data
+  }
+
+  function prefecturesConvertRGB(prefecture){
+    function heatMapColorforValue(value){
+      var h = (1.0 - value) * 240
+      return "hsl(" + h + ", 100%, 50%)";
+    }
+    
+
+
+    return heatMapColorforValue(prefecture)
+  }
+
+  function nomalizePrefectures(prefectures, new_patient_person_number){
+    const max = Math.max(...prefectures)
+    const prefs = prefectures.map(function(x){
+        return x / max;
+    })
+    return prefs
+  }
+
+  function defineAreas(data){
+    let areas = []
+    const prefectures = nomalizePrefectures(data.prefectures, data.new_patient_person_number)
+    for (let i=1;i<=47;i++) {
+      areas.push(
+        {
+          "code": i, 
+          "color": prefecturesConvertRGB(prefectures[i-1]) 
+        }
+      )
+    }
+    return areas
+  }
+
+  function main(){
+    const data = defineData()
+    const areas = defineAreas(data)
+  
+    const d = new jpmap.japanMap(document.getElementById("japan-map"), {
+      areas: areas,
+      height: 270,
+      lineWidth: 0,
+      onSelect: function(data){
+        alert(data.name);
+      }
+    });
+  }
+
+  main()
+})
+
+

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,8 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 
+require("japan-heatmap")
+require("sidebar-covid-card")
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/javascript/sidebar-covid-card.js
+++ b/app/javascript/sidebar-covid-card.js
@@ -1,0 +1,80 @@
+document.addEventListener("turbolinks:load", function(){
+
+  function defineData(){
+    const data = {
+      "date" : "2020/08/27",
+      "total_patient_person_number": 65769,
+      "new_patient_person_number": 865,
+      "prefectures" : [10,2,0,1,0,0,7,8,1,18,69,45,250,66,1,8,13,13,0,6,2,12,39,6,5,27,94,22,4,0,0,0,1,1,6,4,0,0,0,64,2,7,6,1,1,2,36]
+    }
+    return data
+  }
+
+  function prefecturesConvertRGB(prefecture){
+    function heatMapColorforValue(value){
+      var h = (1.0 - value) * 240
+      return "hsl(" + h + ", 100%, 50%)";
+    }
+    
+
+
+    return heatMapColorforValue(prefecture)
+  }
+
+  function nomalizePrefectures(prefectures, new_patient_person_number){
+    const max = Math.max(...prefectures)
+    const prefs = prefectures.map(function(x){
+        return x / max;
+    })
+    return prefs
+  }
+
+  function defineAreas(data){
+    let areas = []
+    const prefectures = data.prefectures
+    const prefecturesNomailse = nomalizePrefectures(data.prefectures, data.new_patient_person_number)
+
+    const prefectureNames = ["北海道","青森県","岩手県","宮城県","秋田県","山形県","福島県","茨城県","栃木県","群馬県","埼玉県","千葉県","東京都","神奈川県","新潟県","富山県","石川県","福井県","山梨県","長野県","岐阜県","静岡県","愛知県","三重県","滋賀県","京都府","大阪府","兵庫県","奈良県","和歌山県","鳥取県","島根県","岡山県","広島県","山口県","徳島県","香川県","愛媛県","高知県","福岡県","佐賀県","長崎県","熊本県","大分県","宮崎県","鹿児島県","沖縄県"]
+    for (let i=1;i<=47;i++) {
+      areas.push(
+        {
+          "code": i, 
+          "color": prefecturesConvertRGB(prefecturesNomailse[i-1]),
+          "name" : prefectureNames[i-1],
+          "data" : prefectures[i-1]
+        }
+      )
+    }
+    return areas
+  }
+
+  function main(){
+    const data = defineData()
+    const areas = defineAreas(data)
+    
+    areas.forEach(function(area){
+      const html = `
+      <div class="covid-card">
+        <p>本日の新規感染者数</p>
+        <div class="covid-card-main">
+          <div class="covid-card-main__pref">${area.name}</div>
+          <div class="covid-card-main__data" style="color: ${area.color}">${area.data}人</div>
+        </div>
+      </div>
+      `
+
+      const dom = document.getElementById("covid-cards")
+      dom.insertAdjacentHTML("beforeend",html)
+    })
+
+    const totalDom_html = `
+      ${data.new_patient_person_number}人
+    `
+    const totalDom = document.getElementsByClassName("covid-card-main__data--total")[0]
+    totalDom.innerHTML = totalDom_html
+  }
+
+  main()
+})
+
+

--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -2,11 +2,25 @@
 
 .wrapper
   .sidebar
+    #covid-cards
+      .covid-card
+        %p 本日の新規感染者数
+        .covid-card-main
+          .covid-card-main__pref
+            全体
+          .covid-card-main__data.covid-card-main__data--total
+
   .main-contents
     .top-topics
+      .hoge
+      .heatmap-topics
+        %h3
+          新規感染者(#{Date.today.strftime("%Y/%m/%d")})
+        #japan-map
     .article-fields
       - @articles.each do |article|
         = link_to article.url, class: "article" do
           = image_tag "/images/#{article.src}", class: "image"
           .title
             = article.title.truncate(25)
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,12 +6,10 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <script type="text/javascript" src="https://unpkg.com/japan-map-js@1.0.1/dist/jpmap.min.js"></script>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-</head>
-
   </head>
-
   <body>
     <%= yield %>
   </body>


### PR DESCRIPTION
コロナのデータを表示する機能を追加

# 保留事項
現状は手動でデータを取ってきている

# データ元
SIGNATE COVIDチャレンジ (phase1)
https://drive.google.com/drive/folders/1EcVW5JQKMB6zoyfHm8_zLVj---t_hccF